### PR TITLE
fix(seo): corriger lang=fr, ajouter calmistory.com dans le contenu et…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -27,6 +27,7 @@
         {
           "@type": "Organization",
           "name": "Calmi",
+          "alternateName": "Calmistory",
           "url": "https://calmistory.com/",
           "logo": "https://calmistory.com/icon-512.png",
           "description": "Histoires personnalisées pour enfants pour favoriser sommeil, concentration et détente."

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -160,7 +160,7 @@ const Landing: React.FC = () => {
           <Link to="/terms" className="hover:text-foreground">CGU</Link>
           <Link to="/contact" className="hover:text-foreground">Contact</Link>
         </div>
-        <p>© {new Date().getFullYear()} Calmi · Fait avec ❤️ au Québec</p>
+        <p>© {new Date().getFullYear()} Calmi (calmistory.com) · Fait avec ❤️ au Québec</p>
       </footer>
     </div>
   );


### PR DESCRIPTION
… JSON-LD

- lang="en" → lang="fr" : la page était déclarée en anglais alors que tout le contenu est en français
- alternateName "Calmistory" ajouté dans le JSON-LD Organization : Google peut désormais associer la marque Calmi au domaine calmistory.com
- "calmistory.com" ajouté dans le footer de la landing page : le mot-clé apparaît désormais dans le contenu crawlé