### PR TITLE
fix(video): dissocier la lecture des vidéos d'intro du quota de génération

### DIFF
--- a/src/pages/StoryReaderPage.tsx
+++ b/src/pages/StoryReaderPage.tsx
@@ -14,8 +14,6 @@ import { StoryVideoIntro } from "@/components/story/StoryVideoIntro";
 import { getStoryVideoUrl } from "@/utils/supabaseImageUtils";
 import { useToast } from "@/hooks/use-toast";
 import { ToastAction } from "@/components/ui/toast";
-import { useSubscription } from "@/hooks/subscription/useSubscription";
-import { useQuotaChecker } from "@/hooks/subscription/useQuotaChecker";
 import { useSupabaseAuth } from "@/contexts/SupabaseAuthContext";
 import { supabase } from "@/integrations/supabase/client";
 import { formatStoryFromSupabase } from "@/hooks/stories/storyFormatters";
@@ -35,8 +33,6 @@ const StoryReaderPage: React.FC = () => {
   const { children } = useSupabaseChildren();
   const { toggleFavorite } = useStoryFavorites();
   const { userSettings } = useUserSettings();
-  const { limits, subscription } = useSubscription();
-  const { incrementUsage } = useQuotaChecker();
   const [currentStory, setCurrentStory] = useState<Story | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<ReaderError | null>(null);
@@ -299,16 +295,12 @@ const StoryReaderPage: React.FC = () => {
   }
 
 
-  // Vérifier si la vidéo d'intro doit être affichée (avec vérification de quota)
+  // La lecture d'une vidéo déjà générée ne dépend pas du quota : le quota gouverne
+  // uniquement la génération. Une vidéo dont le video_path existe est toujours lisible.
   const videoUrl = currentStory.video_path ? getStoryVideoUrl(currentStory.video_path) : null;
-  const hasVideoQuota = limits && subscription && (
-    limits.max_video_intros_per_period > 0 && 
-    subscription.video_intros_used_this_period < limits.max_video_intros_per_period
-  );
 
   const showVideoIntro =
     videoUrl &&
-    hasVideoQuota &&
     ((userSettings.readingPreferences?.playVideoIntro !== false && !introPlayedRef.current) || forcePlayVideo);
 
   return (

--- a/supabase/migrations/20260522000000_fix_video_quota_reset.sql
+++ b/supabase/migrations/20260522000000_fix_video_quota_reset.sql
@@ -1,0 +1,32 @@
+-- Le reset mensuel des quotas oubliait video_intros_used_this_period, donc ce
+-- compteur ne revenait jamais à zéro et finissait par bloquer la génération de
+-- nouvelles vidéos pour tous les utilisateurs.
+CREATE OR REPLACE FUNCTION public.reset_monthly_quotas()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Reset les quotas pour les abonnements dont la période est expirée
+  UPDATE public.user_subscriptions
+  SET stories_used_this_period = 0,
+      audio_generations_used_this_period = 0,
+      video_intros_used_this_period = 0,
+      current_period_start = current_period_end,
+      current_period_end = CASE
+        WHEN is_annual THEN current_period_end + interval '1 year'
+        ELSE current_period_end + interval '1 month'
+      END,
+      updated_at = now()
+  WHERE current_period_end <= now()
+    AND status = 'active';
+
+  -- Expirer les trials
+  UPDATE public.user_subscriptions
+  SET status = 'expired',
+      updated_at = now()
+  WHERE current_period_end <= now()
+    AND status = 'trial';
+END;
+$$;


### PR DESCRIPTION
## Contexte

Anthony Renard (et tout utilisateur ayant épuisé son quota vidéo) ne pouvait plus **revoir** les vidéos d'intro déjà générées : la carte ouvrait directement le texte de l'histoire.

## Cause

Dans `StoryReaderPage.tsx`, l'affichage de la vidéo d'intro était conditionné par `hasVideoQuota` (`video_intros_used_this_period < max`). Or ce compteur est incrémenté à la **génération** d'une vidéo. Résultat : une fois le quota épuisé, la **lecture** des vidéos déjà générées était bloquée — alors que le quota ne devrait gouverner que la génération.

## Changements

- **`src/pages/StoryReaderPage.tsx`** : suppression de `hasVideoQuota` de la condition `showVideoIntro`. Une vidéo dont le `video_path` existe est désormais toujours lisible. Imports/variables devenus inutiles retirés (`useSubscription`, `useQuotaChecker`, `incrementUsage`).
- **`supabase/migrations/20260522000000_fix_video_quota_reset.sql`** : `reset_monthly_quotas()` réinitialise désormais aussi `video_intros_used_this_period` (oublié dans la version d'origine, ce qui aurait fini par bloquer la génération pour tout le monde).

La génération de nouvelles vidéos reste correctement plafonnée par le quota (logique inchangée dans `TitleSelector`, `FastStoryCreator`, etc.).

## Test plan

- [ ] Compte avec `video_intros_used >= max` et histoire avec `video_path` → la vidéo s'affiche
- [ ] `playVideoIntro: false` dans les settings → la vidéo ne s'affiche PAS (comportement voulu)
- [ ] Bouton « Regarder » du toast (`forcePlayVideo`) → la vidéo s'affiche
- [ ] La génération reste bloquée quand le quota est épuisé

🤖 Generated with [Claude Code](https://claude.com/claude-code)