### PR TITLE
feat(audio): TTS navigateur gratuit + sélecteur voix premium

### DIFF
--- a/src/components/settings/ReadingPreferencesSection.tsx
+++ b/src/components/settings/ReadingPreferencesSection.tsx
@@ -8,8 +8,9 @@ import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { UserSettings } from "@/types/user-settings";
-import { Snail, Turtle, Rabbit, RotateCcw, Lock, Wand2 } from "lucide-react";
+import { Snail, Turtle, Rabbit, RotateCcw, Lock, Wand2, Volume2 } from "lucide-react";
 import { useSubscription } from "@/hooks/subscription/useSubscription";
+import { useFeatureAccess } from "@/hooks/subscription/useFeatureAccess";
 
 // Valeurs par défaut des vitesses
 const DEFAULT_SPEEDS = {
@@ -36,7 +37,10 @@ export const ReadingPreferencesSection: React.FC<ReadingPreferencesSectionProps>
   onUpdateSettings
 }) => {
   const { limits } = useSubscription();
+  const { hasAccess } = useFeatureAccess();
   const canPlayVideoIntro = (limits?.max_video_intros_per_period ?? 0) > 0;
+  const canUsePremiumVoice = hasAccess('audio_generation');
+  const audioMode = userSettings.readingPreferences?.audioMode ?? 'browser';
   
   // État pour savoir quel champ est en cours d'édition
   const [editingKey, setEditingKey] = useState<'slow' | 'normal' | 'fast' | null>(null);
@@ -68,6 +72,18 @@ export const ReadingPreferencesSection: React.FC<ReadingPreferencesSectionProps>
       readingPreferences: {
         ...userSettings.readingPreferences,
         immersiveReadingMode: value
+      }
+    });
+  };
+
+  // Gérer le changement du moteur de lecture audio
+  const handleAudioModeChange = async (value: 'browser' | 'premium') => {
+    // Sécurité : un non-premium ne peut pas activer la voix premium
+    if (value === 'premium' && !canUsePremiumVoice) return;
+    await onUpdateSettings({
+      readingPreferences: {
+        ...userSettings.readingPreferences,
+        audioMode: value
       }
     });
   };
@@ -224,6 +240,54 @@ export const ReadingPreferencesSection: React.FC<ReadingPreferencesSectionProps>
           <div className="text-sm text-muted-foreground">
             Activer la musique de fond lors de la lecture des histoires
           </div>
+        </div>
+
+        {/* Option Voix de lecture audio */}
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <Volume2 className="h-5 w-5 text-primary" />
+                <Label htmlFor="audio-mode" className="text-base font-medium">
+                  Voix de lecture audio
+                </Label>
+              </div>
+              <div className="text-sm text-muted-foreground mr-4">
+                Choisissez la voix utilisée pour lire l'histoire à voix haute.
+              </div>
+            </div>
+            <div className="w-48 xl:w-56">
+              <Select
+                value={audioMode}
+                onValueChange={(value) => handleAudioModeChange(value as 'browser' | 'premium')}
+                disabled={isLoading}
+              >
+                <SelectTrigger id="audio-mode">
+                  <SelectValue placeholder="Sélectionner une voix" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="browser">Voix du navigateur (gratuit)</SelectItem>
+                  <SelectItem value="premium" disabled={!canUsePremiumVoice}>
+                    <span className="flex items-center gap-2">
+                      Voix premium
+                      {!canUsePremiumVoice && <Lock className="h-3.5 w-3.5 text-muted-foreground" />}
+                    </span>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          {audioMode === 'browser' && (
+            <div className="text-xs text-muted-foreground">
+              La voix du navigateur est gratuite mais sa qualité dépend de votre appareil.
+              Sur mobile, la lecture peut s'interrompre si l'écran se verrouille.
+            </div>
+          )}
+          {!canUsePremiumVoice && (
+            <div className="text-sm text-primary font-medium">
+              La voix premium est disponible avec le plan Calmix.
+            </div>
+          )}
         </div>
 
         {/* Option Vidéo d'introduction */}

--- a/src/components/story/ReaderControls.tsx
+++ b/src/components/story/ReaderControls.tsx
@@ -4,7 +4,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Bookmark, CheckCircle, BookOpenCheck, Sun, Moon, Share, Copy, Check } from "lucide-react";
-import { N8nAudioPlayer } from "./reader/N8nAudioPlayer";
+import { StoryAudioControl } from "./reader/StoryAudioControl";
 import { TechnicalDiagnosticButton } from "./reader/TechnicalDiagnosticButton";
 import { MarkAsReadButton } from "./reader/MarkAsReadButton";
 import { ShareStoryManager } from "./ShareStoryManager";
@@ -77,7 +77,7 @@ const ReaderControls: React.FC<ReaderControlsProps> = ({
             
             {/* 1. Génération audio - compact */}
             <div className="shrink-0">
-              <N8nAudioPlayer storyId={storyId} text={story.content} isDarkMode={isDarkMode} />
+              <StoryAudioControl storyId={storyId} text={story.content} isDarkMode={isDarkMode} />
             </div>
 
             {/* Séparateur visuel */}
@@ -154,9 +154,9 @@ const ReaderControls: React.FC<ReaderControlsProps> = ({
             
             {/* Ligne 1 : Audio - centré */}
             <div className="flex items-center justify-center">
-              <N8nAudioPlayer 
-                storyId={storyId} 
-                text={story.content} 
+              <StoryAudioControl
+                storyId={storyId}
+                text={story.content}
                 isDarkMode={isDarkMode}
                 compact={true}
               />

--- a/src/components/story/reader/StoryAudioControl.tsx
+++ b/src/components/story/reader/StoryAudioControl.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Play, Pause, Volume2 } from 'lucide-react';
+import { N8nAudioPlayer } from './N8nAudioPlayer';
+import { useUserSettings } from '@/hooks/settings/useUserSettings';
+import { useFeatureAccess } from '@/hooks/subscription/useFeatureAccess';
+import { useToast } from '@/hooks/use-toast';
+
+interface StoryAudioControlProps {
+  storyId: string;
+  text: string;
+  isDarkMode?: boolean;
+  compact?: boolean;
+}
+
+const MOBILE_HINT_SESSION_KEY = 'calmi_browser_tts_mobile_hint_shown';
+
+/**
+ * Lecture audio gratuite via le Web Speech API (voix du navigateur).
+ * Contourne le bug Chrome qui coupe la synthèse après ~15s en relançant
+ * périodiquement pause()/resume() tant que la lecture est active.
+ */
+const BrowserTTSPlayer: React.FC<StoryAudioControlProps> = ({ text, isDarkMode = false, compact = false }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const keepAliveRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const { toast } = useToast();
+
+  const clearKeepAlive = () => {
+    if (keepAliveRef.current) {
+      clearInterval(keepAliveRef.current);
+      keepAliveRef.current = null;
+    }
+  };
+
+  const stop = () => {
+    clearKeepAlive();
+    if (typeof window !== 'undefined' && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
+    setIsPlaying(false);
+  };
+
+  // Nettoyage au démontage
+  useEffect(() => stop, []);
+
+  const play = () => {
+    if (!('speechSynthesis' in window) || typeof SpeechSynthesisUtterance === 'undefined') {
+      toast({
+        title: 'Lecture indisponible',
+        description: "La voix du navigateur n'est pas supportée sur cet appareil.",
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!text || text.trim().length === 0) {
+      toast({ title: 'Erreur', description: 'Aucun texte à lire', variant: 'destructive' });
+      return;
+    }
+
+    // Toujours repartir d'un état propre
+    window.speechSynthesis.cancel();
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'fr-FR';
+    const frVoice = window.speechSynthesis.getVoices().find((v) => v.lang?.toLowerCase().startsWith('fr'));
+    if (frVoice) utterance.voice = frVoice;
+
+    utterance.onstart = () => setIsPlaying(true);
+    utterance.onend = () => {
+      clearKeepAlive();
+      setIsPlaying(false);
+    };
+    utterance.onerror = () => {
+      clearKeepAlive();
+      setIsPlaying(false);
+    };
+
+    window.speechSynthesis.speak(utterance);
+
+    // Contournement du bug Chrome (coupure ~15s)
+    clearKeepAlive();
+    keepAliveRef.current = setInterval(() => {
+      if (window.speechSynthesis.speaking) {
+        window.speechSynthesis.pause();
+        window.speechSynthesis.resume();
+      }
+    }, 10000);
+
+    // Avertissement mobile (une seule fois par session)
+    if (typeof sessionStorage !== 'undefined' && !sessionStorage.getItem(MOBILE_HINT_SESSION_KEY)) {
+      sessionStorage.setItem(MOBILE_HINT_SESSION_KEY, '1');
+      toast({
+        title: 'Lecture démarrée',
+        description: "Sur mobile, gardez l'écran allumé : la lecture s'arrête si l'écran se verrouille.",
+      });
+    }
+  };
+
+  const handleClick = () => (isPlaying ? stop() : play());
+
+  if (compact) {
+    return (
+      <Button onClick={handleClick} variant="outline" size="icon" className="h-8 w-8" title="Lire l'histoire">
+        {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      variant="outline"
+      size="sm"
+      className={isDarkMode ? 'border-gray-600 text-white hover:bg-gray-700' : ''}
+    >
+      {isPlaying ? <Pause className="h-4 w-4 mr-2" /> : <Volume2 className="h-4 w-4 mr-2" />}
+      {isPlaying ? 'Pause' : "Lire l'histoire"}
+    </Button>
+  );
+};
+
+/**
+ * Bouton de lecture audio unique.
+ * Choisit le moteur selon la préférence utilisateur `audioMode` :
+ * - 'premium' (et accès actif) -> voix Speechify via N8nAudioPlayer
+ * - sinon -> voix du navigateur (gratuit, Web Speech API)
+ */
+export const StoryAudioControl: React.FC<StoryAudioControlProps> = (props) => {
+  const { userSettings } = useUserSettings();
+  const { hasAccess } = useFeatureAccess();
+
+  const audioMode = userSettings.readingPreferences?.audioMode ?? 'browser';
+  const usePremium = audioMode === 'premium' && hasAccess('audio_generation');
+
+  if (usePremium) {
+    return <N8nAudioPlayer {...props} />;
+  }
+
+  return <BrowserTTSPlayer {...props} />;
+};

--- a/src/hooks/settings/useUpdateUserSettings.ts
+++ b/src/hooks/settings/useUpdateUserSettings.ts
@@ -73,6 +73,8 @@ export const useUpdateUserSettings = (
         supabaseData.custom_speed_fast = newSettings.readingPreferences.customSpeedFast;
       if (newSettings.readingPreferences?.immersiveReadingMode !== undefined)
         supabaseData.immersive_reading_mode = newSettings.readingPreferences.immersiveReadingMode;
+      if (newSettings.readingPreferences?.audioMode !== undefined)
+        supabaseData.audio_mode = newSettings.readingPreferences.audioMode;
 
       // Vérifier si l'utilisateur existe déjà dans la table
       const { data: existingUser, error: checkError } = await supabase

--- a/src/hooks/settings/useUserSettingsState.ts
+++ b/src/hooks/settings/useUserSettingsState.ts
@@ -28,6 +28,7 @@ export const useUserSettingsState = () => {
       customSpeedNormal: 120,
       customSpeedFast: 150,
       immersiveReadingMode: 'pulse',
+      audioMode: 'browser',
     }
   });
 
@@ -81,6 +82,7 @@ export const useUserSettingsState = () => {
               customSpeedNormal: data.custom_speed_normal ?? 120,
               customSpeedFast: data.custom_speed_fast ?? 150,
               immersiveReadingMode: data.immersive_reading_mode ?? 'pulse',
+              audioMode: data.audio_mode ?? 'browser',
             }
           });
         } else {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1336,6 +1336,7 @@ export type Database = {
       }
       users: {
         Row: {
+          audio_mode: string
           auto_scroll_enabled: boolean | null
           background_music_enabled: boolean | null
           created_at: string
@@ -1359,6 +1360,7 @@ export type Database = {
           video_intro_enabled: boolean | null
         }
         Insert: {
+          audio_mode?: string
           auto_scroll_enabled?: boolean | null
           background_music_enabled?: boolean | null
           created_at?: string
@@ -1382,6 +1384,7 @@ export type Database = {
           video_intro_enabled?: boolean | null
         }
         Update: {
+          audio_mode?: string
           auto_scroll_enabled?: boolean | null
           background_music_enabled?: boolean | null
           created_at?: string

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -20,6 +20,7 @@ export interface UserSettings {
     customSpeedNormal: number; // vitesse personnalisée Tortue (50-200)
     customSpeedFast: number; // vitesse personnalisée Lapin (50-200)
     immersiveReadingMode: 'none' | 'pulse' | 'karaoke' | 'brush'; // Mode de lecture immersive
+    audioMode: 'browser' | 'premium'; // Moteur de lecture audio: navigateur (gratuit) ou Speechify (premium)
   };
 }
 

--- a/supabase/migrations/20260522120000_add_audio_mode_preference.sql
+++ b/supabase/migrations/20260522120000_add_audio_mode_preference.sql
@@ -1,0 +1,17 @@
+-- Préférence du moteur de lecture audio par utilisateur
+-- 'browser' = Web Speech API (voix du navigateur, gratuit pour tous)
+-- 'premium' = Speechify (voix premium, gated par feature audio_generation)
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS audio_mode TEXT NOT NULL DEFAULT 'browser';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_audio_mode_check'
+  ) THEN
+    ALTER TABLE public.users
+      ADD CONSTRAINT users_audio_mode_check CHECK (audio_mode IN ('browser', 'premium'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.users.audio_mode IS 'Preference du moteur de lecture audio: browser (Web Speech API gratuit) ou premium (Speechify)';


### PR DESCRIPTION
## Résumé

Implémente la lecture audio à deux niveaux demandée :
- **Gratuit pour tous** : voix du navigateur (Web Speech API), disponible sans quota
- **Premium** : voix Speechify existante, accessible via les paramètres pour les abonnés Calmix

## Changements

### Nouveau composant `StoryAudioControl`
Bouton unique dans le lecteur qui branche sur la préférence `audioMode` :
- `browser` (défaut) → Web Speech API avec :
  - Contournement du bug Chrome ~15s (pause/resume périodique)
  - Toast d'avertissement mobile au premier lancement (lecture stoppée si écran verrouillé)
  - Voix fr-FR auto-sélectionnée si disponible
- `premium` → délègue à `N8nAudioPlayer` (flux Speechify inchangé)

### Sélecteur dans les Paramètres
Section « Voix de lecture audio » dans **Préférences de lecture** :
- Option premium verrouillée + upsell Calmix pour les non-abonnés (même pattern que la vidéo d'intro)
- Note d'avertissement mobile en mode navigateur

### Base de données
Migration `20260522120000_add_audio_mode_preference.sql` — colonne `audio_mode TEXT DEFAULT 'browser'` sur `users` (déjà appliquée en production).

## Tests
- ✅ `tsc --noEmit` passe (exit 0)
- ✅ `vite build` passe (exit 0)
- ✅ App démarre sans erreur JS côté client
- ⏳ Test interactif à valider dans le preview Lovable (login requis)

## Note
Le pipeline premium Speechify est actuellement en erreur (dernier audio généré : 2026-03-22) — à régler séparément, hors scope de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)