### PR TITLE
fix(admin): corriger les liens du panneau Administration (404)

### DIFF
--- a/src/components/settings/AdminLinksSection.tsx
+++ b/src/components/settings/AdminLinksSection.tsx
@@ -20,42 +20,42 @@ export const AdminLinksSection = () => {
       title: 'Superadmin · Billing',
       description: 'Pilotage Stripe, abonnés et webhooks',
       icon: CreditCard,
-      path: '/superadmin',
+      path: '/app/superadmin',
       color: 'text-primary'
     }] : []),
     {
       title: 'Gestion Beta Testeurs',
       description: 'Valider les demandes et gérer les codes d\'invitation',
       icon: Users,
-      path: '/admin/beta-testers',
+      path: '/app/admin/beta-testers',
       color: 'text-blue-500'
     },
     {
       title: 'Gestion Prompts',
       description: 'Modifier les templates de prompts IA',
       icon: FileText,
-      path: '/admin/prompts',
+      path: '/app/admin/prompts',
       color: 'text-green-500'
     },
     {
       title: 'Configuration TTS',
       description: 'Paramètres de génération audio',
       icon: Volume2,
-      path: '/admin/tts-config',
+      path: '/app/admin/tts-config',
       color: 'text-purple-500'
     },
     {
       title: 'Musiques de fond',
       description: 'Uploader et gérer les musiques d\'ambiance',
       icon: Music,
-      path: '/admin/sounds',
+      path: '/app/admin/sounds',
       color: 'text-pink-500'
     },
     {
       title: 'Feedback Utilisateurs',
       description: 'Consulter les retours utilisateurs',
       icon: MessageSquare,
-      path: '/admin/feedback',
+      path: '/app/admin/feedback',
       color: 'text-orange-500'
     }
   ];


### PR DESCRIPTION
## Problème

Toutes les pages du panneau Administration retournaient une erreur **404**.

## Cause racine

AdminLinksSection.tsx utilisait des chemins sans le préfixe \/app\ (ex: \/admin/prompts\), alors que ces routes sont imbriquées sous \/app\ dans \App.tsx\. Le wildcard \*\ de React Router capturait ces URLs et redirigait vers \/404\.

## Fix

Correction des 6 chemins dans \src/components/settings/AdminLinksSection.tsx\ :

| Avant ❌ | Après ✅ |
|---|---|
| \/superadmin\ | \/app/superadmin\ |
| \/admin/beta-testers\ | \/app/admin/beta-testers\ |
| \/admin/prompts\ | \/app/admin/prompts\ |
| \/admin/tts-config\ | \/app/admin/tts-config\ |
| \/admin/sounds\ | \/app/admin/sounds\ |
| \/admin/feedback\ | \/app/admin/feedback\ |

## Fichier modifié

- \src/components/settings/AdminLinksSection.tsx\

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)