### PR TITLE
feat(settings): sélecteur de mode audio (navigateur vs premium)

### DIFF
--- a/src/components/settings/AudioSection.tsx
+++ b/src/components/settings/AudioSection.tsx
@@ -1,0 +1,171 @@
+
+import React from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Badge } from '@/components/ui/badge';
+import { Headphones, Globe, Sparkles, Lock, CheckCircle2 } from 'lucide-react';
+import { UserSettings } from '@/types/user-settings';
+import { useSubscription } from '@/hooks/subscription/useSubscription';
+import { cn } from '@/lib/utils';
+
+interface AudioSectionProps {
+  userSettings: UserSettings;
+  isLoading: boolean;
+  onUpdateSettings: (newSettings: Partial<UserSettings>) => Promise<void>;
+}
+
+export const AudioSection: React.FC<AudioSectionProps> = ({
+  userSettings,
+  isLoading,
+  onUpdateSettings,
+}) => {
+  const { limits } = useSubscription();
+  const canUsePremiumAudio = (limits?.audio_generations_per_month ?? 0) > 0;
+
+  const currentMode = userSettings.readingPreferences?.audioMode ?? 'browser';
+
+  const handleSelectMode = async (mode: 'browser' | 'premium') => {
+    if (mode === 'premium' && !canUsePremiumAudio) return;
+    if (isLoading) return;
+
+    await onUpdateSettings({
+      readingPreferences: {
+        ...userSettings.readingPreferences,
+        audioMode: mode,
+      },
+    });
+  };
+
+  const options: Array<{
+    id: 'browser' | 'premium';
+    icon: React.ReactNode;
+    label: string;
+    description: string;
+    badge?: string;
+    locked?: boolean;
+  }> = [
+    {
+      id: 'browser',
+      icon: <Globe className="h-5 w-5" />,
+      label: 'Audio navigateur',
+      description: 'Lecture via la synthèse vocale intégrée à votre navigateur. Gratuit, sans limite.',
+    },
+    {
+      id: 'premium',
+      icon: <Sparkles className="h-5 w-5" />,
+      label: 'Audio premium',
+      description: 'Voix haute qualité générée par IA (ElevenLabs), disponible à tout moment.',
+      badge: 'Calmix',
+      locked: !canUsePremiumAudio,
+    },
+  ];
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Headphones className="h-5 w-5 text-primary" />
+          Audio
+        </CardTitle>
+        <CardDescription>
+          Choisissez le mode de lecture audio pour vos histoires
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <TooltipProvider delayDuration={0}>
+          {options.map((option) => {
+            const isSelected = currentMode === option.id;
+            const isDisabled = option.locked || isLoading;
+
+            const card = (
+              <button
+                key={option.id}
+                type="button"
+                disabled={isDisabled}
+                onClick={() => handleSelectMode(option.id)}
+                className={cn(
+                  'w-full text-left rounded-lg border-2 p-4 transition-all',
+                  'flex items-start gap-3',
+                  isSelected
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border bg-background hover:border-primary/50 hover:bg-muted/40',
+                  isDisabled && 'opacity-50 cursor-not-allowed hover:border-border hover:bg-background'
+                )}
+              >
+                {/* Icône */}
+                <div
+                  className={cn(
+                    'shrink-0 mt-0.5 rounded-md p-1.5',
+                    isSelected ? 'text-primary bg-primary/10' : 'text-muted-foreground bg-muted'
+                  )}
+                >
+                  {option.icon}
+                </div>
+
+                {/* Texte */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Label
+                      className={cn(
+                        'text-sm font-medium cursor-pointer',
+                        isDisabled && 'cursor-not-allowed'
+                      )}
+                    >
+                      {option.label}
+                    </Label>
+
+                    {option.badge && (
+                      <Badge
+                        variant="secondary"
+                        className="text-xs px-1.5 py-0"
+                      >
+                        {option.badge}
+                      </Badge>
+                    )}
+
+                    {option.locked && (
+                      <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+                    {option.description}
+                  </p>
+                  {option.locked && (
+                    <p className="text-xs text-primary font-medium mt-1">
+                      Disponible avec le plan Calmix
+                    </p>
+                  )}
+                </div>
+
+                {/* Indicateur de sélection */}
+                <div className="shrink-0 mt-0.5">
+                  {isSelected ? (
+                    <CheckCircle2 className="h-5 w-5 text-primary" />
+                  ) : (
+                    <div className="h-5 w-5 rounded-full border-2 border-muted-foreground/30" />
+                  )}
+                </div>
+              </button>
+            );
+
+            if (option.locked) {
+              return (
+                <Tooltip key={option.id}>
+                  <TooltipTrigger asChild>
+                    <div>{card}</div>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p>Disponible à partir du plan Calmix</p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            }
+
+            return card;
+          })}
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/story/ReaderControls.tsx
+++ b/src/components/story/ReaderControls.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Bookmark, CheckCircle, BookOpenCheck, Sun, Moon, Share, Copy, Check } from "lucide-react";
 import { N8nAudioPlayer } from "./reader/N8nAudioPlayer";
+import { TextToSpeech } from "./TextToSpeech";
 import { TechnicalDiagnosticButton } from "./reader/TechnicalDiagnosticButton";
 import { MarkAsReadButton } from "./reader/MarkAsReadButton";
 import { ShareStoryManager } from "./ShareStoryManager";
@@ -13,6 +14,8 @@ import BackgroundSoundButton from "./reader/BackgroundSoundButton";
 import { extractObjectiveValue } from "@/utils/objectiveUtils";
 import { ReadingSpeedSelector } from "./reader/controls/ReadingSpeedSelector";
 import { toast } from "@/hooks/use-toast";
+import { useUserSettings } from "@/hooks/settings/useUserSettings";
+import { useSubscription } from "@/hooks/subscription/useSubscription";
 interface ReaderControlsProps {
   fontSize: number;
   setFontSize: (size: number) => void;
@@ -39,6 +42,14 @@ const ReaderControls: React.FC<ReaderControlsProps> = ({
 }) => {
   const [isMounted, setIsMounted] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
+  const { userSettings } = useUserSettings();
+  const { limits } = useSubscription();
+
+  // Utiliser le mode audio choisi dans les paramètres,
+  // mais forcer 'browser' si l'abonnement ne donne pas accès à l'audio premium
+  const canUsePremiumAudio = (limits?.audio_generations_per_month ?? 0) > 0;
+  const preferredAudioMode = userSettings.readingPreferences?.audioMode ?? 'browser';
+  const audioMode = (preferredAudioMode === 'premium' && canUsePremiumAudio) ? 'premium' : 'browser';
   const {
     showShareDialog,
     openShareDialog,
@@ -77,7 +88,11 @@ const ReaderControls: React.FC<ReaderControlsProps> = ({
             
             {/* 1. Génération audio - compact */}
             <div className="shrink-0">
-              <N8nAudioPlayer storyId={storyId} text={story.content} isDarkMode={isDarkMode} />
+              {audioMode === 'premium' ? (
+                <N8nAudioPlayer storyId={storyId} text={story.content} isDarkMode={isDarkMode} />
+              ) : (
+                <TextToSpeech text={story.content} isDarkMode={isDarkMode} />
+              )}
             </div>
 
             {/* Séparateur visuel */}
@@ -154,12 +169,16 @@ const ReaderControls: React.FC<ReaderControlsProps> = ({
             
             {/* Ligne 1 : Audio - centré */}
             <div className="flex items-center justify-center">
-              <N8nAudioPlayer 
-                storyId={storyId} 
-                text={story.content} 
-                isDarkMode={isDarkMode}
-                compact={true}
-              />
+              {audioMode === 'premium' ? (
+                <N8nAudioPlayer
+                  storyId={storyId}
+                  text={story.content}
+                  isDarkMode={isDarkMode}
+                  compact={true}
+                />
+              ) : (
+                <TextToSpeech text={story.content} isDarkMode={isDarkMode} />
+              )}
             </div>
 
             {/* Ligne 2 : Vitesse + Musique + Lu - tous centrés */}

--- a/src/hooks/settings/useUpdateUserSettings.ts
+++ b/src/hooks/settings/useUpdateUserSettings.ts
@@ -73,6 +73,8 @@ export const useUpdateUserSettings = (
         supabaseData.custom_speed_fast = newSettings.readingPreferences.customSpeedFast;
       if (newSettings.readingPreferences?.immersiveReadingMode !== undefined)
         supabaseData.immersive_reading_mode = newSettings.readingPreferences.immersiveReadingMode;
+      if (newSettings.readingPreferences?.audioMode !== undefined)
+        supabaseData.audio_mode = newSettings.readingPreferences.audioMode;
 
       // Vérifier si l'utilisateur existe déjà dans la table
       const { data: existingUser, error: checkError } = await supabase

--- a/src/hooks/settings/useUserSettingsState.ts
+++ b/src/hooks/settings/useUserSettingsState.ts
@@ -28,6 +28,7 @@ export const useUserSettingsState = () => {
       customSpeedNormal: 120,
       customSpeedFast: 150,
       immersiveReadingMode: 'pulse',
+      audioMode: 'browser',
     }
   });
 
@@ -81,6 +82,7 @@ export const useUserSettingsState = () => {
               customSpeedNormal: data.custom_speed_normal ?? 120,
               customSpeedFast: data.custom_speed_fast ?? 150,
               immersiveReadingMode: data.immersive_reading_mode ?? 'pulse',
+              audioMode: (data.audio_mode as 'browser' | 'premium') ?? 'browser',
             }
           });
         } else {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { NotificationsSection } from '@/components/settings/NotificationsSection
 import { SecuritySection } from '@/components/settings/SecuritySection';
 import { AccountManagementSection } from '@/components/settings/AccountManagementSection';
 import { ReadingPreferencesSection } from '@/components/settings/ReadingPreferencesSection';
+import { AudioSection } from '@/components/settings/AudioSection';
 import { ThemeSection } from '@/components/settings/ThemeSection';
 import { AdminLinksSection } from '@/components/settings/AdminLinksSection';
 import { FamilySection } from '@/components/settings/FamilySection';
@@ -184,6 +185,12 @@ const Settings = () => {
       <ThemeSection />
 
       <ReadingPreferencesSection
+        userSettings={userSettings}
+        isLoading={isSubmitting}
+        onUpdateSettings={updateUserSettings}
+      />
+
+      <AudioSection
         userSettings={userSettings}
         isLoading={isSubmitting}
         onUpdateSettings={updateUserSettings}

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -20,6 +20,7 @@ export interface UserSettings {
     customSpeedNormal: number; // vitesse personnalisée Tortue (50-200)
     customSpeedFast: number; // vitesse personnalisée Lapin (50-200)
     immersiveReadingMode: 'none' | 'pulse' | 'karaoke' | 'brush'; // Mode de lecture immersive
+    audioMode: 'browser' | 'premium'; // Mode audio : navigateur (gratuit) ou premium (n8n/ElevenLabs)
   };
 }
 


### PR DESCRIPTION
## Résumé

Ajout d'un sélecteur de mode audio dans la page **Paramètres**, permettant à l'utilisateur de choisir entre le TTS gratuit du navigateur et l'audio premium (ElevenLabs via n8n).

## Changements

### Nouvelle section « Audio » dans les Paramètres
- Positionnée entre « Préférences de lecture » et « Kindle »
- Interface radio-cards avec deux options :
  - 🌐 **Audio navigateur** — `speechSynthesis` natif, gratuit, sans limite
  - ✨ **Audio premium** — ElevenLabs via n8n, verrouillé pour calmini/calmidium avec cadenas + tooltip « Disponible à partir du plan Calmix »

### Persistance
- Lecture/écriture dans la colonne `audio_mode` de la table `users` (colonne déjà présente, défaut `browser`)
- Mis à jour dans `UserSettings.readingPreferences.audioMode`

### Comportement dans le lecteur
- `ReaderControls` lit la préférence et affiche `TextToSpeech` (navigateur) ou `N8nAudioPlayer` (premium) — desktop et mobile
- Sécurité côté client : si l'abonnement ne donne pas accès à `audio_generations_per_month`, le mode est forcé à `browser` quoi que soit la préférence sauvegardée

## Fichiers modifiés
| Fichier | Changement |
|---------|-----------|
| `src/components/settings/AudioSection.tsx` | ✨ Nouveau composant |
| `src/types/user-settings.ts` | Ajout `audioMode` |
| `src/hooks/settings/useUserSettingsState.ts` | Défaut + chargement DB |
| `src/hooks/settings/useUpdateUserSettings.ts` | Mapping → `audio_mode` |
| `src/pages/Settings.tsx` | Ajout `<AudioSection />` |
| `src/components/story/ReaderControls.tsx` | Rendu conditionnel audio |

🤖 Generated with [Claude Code](https://claude.com/claude-code)