### PR TITLE
feat(create): réserver le mode "Discuter avec Calmi" au superadmin

### DIFF
--- a/src/components/story/chat/CreationModeToggle.tsx
+++ b/src/components/story/chat/CreationModeToggle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ListChecks, MessageCircle, Zap } from 'lucide-react';
 import type { CreationMode } from '@/types/chatbot';
+import { useIsSuperAdmin } from '@/hooks/auth/useIsSuperAdmin';
 
 interface CreationModeToggleProps {
   mode: CreationMode;
@@ -8,6 +9,8 @@ interface CreationModeToggleProps {
 }
 
 const CreationModeToggle: React.FC<CreationModeToggleProps> = ({ mode, onModeChange }) => {
+  const { isSuperAdmin } = useIsSuperAdmin();
+
   return (
     <div className="flex items-center justify-center mb-6">
       <div className="inline-flex rounded-xl bg-muted/50 p-1 border border-border/50">
@@ -43,21 +46,23 @@ const CreationModeToggle: React.FC<CreationModeToggleProps> = ({ mode, onModeCha
           <span>Histoires rapides</span>
         </button>
 
-        <button
-          type="button"
-          onClick={() => onModeChange('chat')}
-          className={`
-            flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium
-            transition-all duration-200
-            ${mode === 'chat'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-            }
-          `}
-        >
-          <MessageCircle className="h-4 w-4" />
-          <span>BETA - Discuter avec Calmi</span>
-        </button>
+        {isSuperAdmin && (
+          <button
+            type="button"
+            onClick={() => onModeChange('chat')}
+            className={`
+              flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium
+              transition-all duration-200
+              ${mode === 'chat'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+              }
+            `}
+          >
+            <MessageCircle className="h-4 w-4" />
+            <span>BETA - Discuter avec Calmi</span>
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Le bouton de mode "BETA - Discuter avec Calmi" de la vue "Créer" n'est désormais visible que pour le superadmin (RPC `is_super_admin`).
- Aucun impact pour les utilisateurs normaux : le bouton reste masqué pendant le chargement du statut, et le mode par défaut est `guided`.

## Test plan
- [ ] En tant que superadmin : le bouton "BETA - Discuter avec Calmi" apparaît dans la vue "Créer".
- [ ] En tant qu'utilisateur normal : seuls "Mode guidé" et "Histoires rapides" sont visibles, sans flash du bouton chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)